### PR TITLE
instance creation and group instance fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Here is the full list of endpoints by category that this wrapper does implements
 
 **Instances API** :
 
--   `getInstance`, `getInstanceShortName`, `sendSelfInvite`, `getInstanceByShortName`, `createInstance`
+-   `getInstance`, `getInstanceShortName`, `sendSelfInvite`, `getInstanceByShortName`, ~~`createInstance`~~, `createNormalInstance`🆕, `createGroupInstance`🆕
 
 **Notifications API** :
 
@@ -179,6 +179,7 @@ Here is the full list of endpoints by category that this wrapper does implements
 
 ! Marks of an asterics are either not yet implemented or yet to be added. Progress is going fast, come back to see the update.
 ! Crossed Endpoints are deprecated and aren't used by VRChat anymore or will soon stop to be.
+! Instance creation have two separate endpoints now! One for regular instance and one for group instance. For regular instance you can also just create the instance ID without touching the API. Function is called `generateNormalInstanceIdOnly()` in the `instanceApi`.
 
 ## WebSocket
 

--- a/src/VRChatAPI.ts
+++ b/src/VRChatAPI.ts
@@ -33,6 +33,7 @@ export class VRChatAPI {
     public static ApiBaseUrl: string = 'https://api.vrchat.cloud/api/1';
     headerAgent: string = process.env.USER_AGENT || 'ExampleApp/1.0.0 Email@example.com';
     basePath: string = ApiPaths.apiBasePath;
+    basePath2: string = ApiPaths.apiBasePath;
     cookiesLoaded = false;
 
     authApi: AuthApi = new AuthApi(this);

--- a/src/requests/BaseApi.ts
+++ b/src/requests/BaseApi.ts
@@ -34,7 +34,12 @@ export class BaseApi {
         });
 
         // if all query parameters are present in the query params variable then we can replace them with our parameter from the template
-        const currentPath = this.baseClass.basePath + pathFormated;
+        let currentPath = '';
+        if (currentRequest.secondPath) {
+            currentPath = this.baseClass.basePath2 + pathFormated;
+        } else {
+            currentPath = this.baseClass.basePath + pathFormated;
+        }
         const url: URL = new URL(currentPath);
 
         if (queryOptions && queryOptions.toString()) {

--- a/src/requests/InstancesApi.ts
+++ b/src/requests/InstancesApi.ts
@@ -32,17 +32,21 @@ export class InstanceApi extends BaseApi {
     }
 
     /**
-     * Returns an instance short name.
+     * Returns an instance short name and secure name.
+     * The secure name is used mainly for group instance.
+     * Only the instance owner can get the short name and secure name.
      */
     public async getInstanceShortName({
-        worldId,
         instanceId,
     }: Inst.GetInstanceShortNameRequest): Promise<Inst.InstanceShortName> {
+        const parameters: URLSearchParams = new URLSearchParams();
+
+        parameters.append('permanentify', 'true');
+
         const paramRequest: executeRequestType = {
             currentRequest: ApiPaths.instances.getInstanceShortName,
-            pathFormated: ApiPaths.instances.getInstanceShortName.path
-                .replace('{worldId}', worldId)
-                .replace('{instanceId}', instanceId),
+            pathFormated: ApiPaths.instances.getInstanceShortName.path.replace('{instanceId}', instanceId),
+            queryOptions: parameters,
         };
 
         return await this.executeRequest<Inst.InstanceShortName>(paramRequest);
@@ -75,25 +79,202 @@ export class InstanceApi extends BaseApi {
     }
 
     /**
-     * Return a `instance` type object from the new instance being created.
+     * This function is used to create a new instance. Returns the instance object that was created.
+     * ### **[Important]**
+     * - Only for creating instances that are not group instances.
+     *
+     * @param worldId The ID of the world you want to create an instance in.
+     * @param region The region of the instance. Enum: `InstanceRegionType`.
+     * @param instanceType The type of instance you are creating. Enum: `InstanceAccessNormalType`.
+     * @param instanceCode **[Optional]** The code of the instance. If not provided, a random code will be generated. (Any 1-5 digit number or characters are valid.)
+     * @param ownerId **[Optional]** The owner ID of the instance. BUT **is Required if the instance isn't public.** (Must be the USER ID of the bot account this script is controlling).
+     *
+     * @returns {Promise<Inst.Instance>} The instance object that was created.
      */
-    public createRegularInstance({
+    public generateNormalInstance({
         worldId,
-        ownerId,
         region,
+        instanceType,
+        instanceCode,
+        ownerId,
     }: Inst.CreateRegularInstanceRequest): Promise<Inst.Instance> {
-        const body: Inst.CreateRegularInstanceRequest = {
-            worldId,
+        if (instanceType !== Inst.InstanceAccessNormalType.Public) {
+            if (!ownerId) throw new Error('You need to provide the ownerId parameter for a non-public instance!');
+        } else {
+            if (ownerId)
+                console.warn('The ownerId parameter is not required for a public instance! It will be ignored.');
+        }
+
+        // gnerate a random code that is 1-5 digits long maximum
+        if (!instanceCode) {
+            instanceCode = Math.floor(Math.random() * 99999) + 1;
+        } else {
+            if (instanceCode.toString().length > 5 || instanceCode.toString().length < 1) {
+                throw new Error('The instanceCode must be between 1-5 digits/characters long!');
+            }
+        }
+
+        let instanceId = '';
+
+        instanceId = worldId + ':' + instanceCode;
+        const nonce = this.getRandomNonce();
+
+        if (instanceType === Inst.InstanceAccessNormalType.Public) {
+            // Public instance type
+            instanceId += '~region(' + region + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Friends) {
+            // Friends instance type
+            instanceId += '~friends(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Friends_Plus) {
+            // Friends+ instance type
+            instanceId += '~hidden(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Invite) {
+            // Invite instance type
+            instanceId += '~private(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else {
+            // Invite+ instance type
+            instanceId += '~private(' + ownerId + ')~canRequestInvite~region(' + region + ')~nonce(' + nonce + ')';
+        }
+
+        const paramRequest: executeRequestType = {
+            currentRequest: ApiPaths.instances.createNormalInstance,
+            pathFormated: ApiPaths.instances.createNormalInstance.path.replace('{instanceId}', instanceId),
+        };
+
+        // console.log('instanceId: ', instanceId);
+
+        return this.executeRequest<Inst.Instance>(paramRequest);
+    }
+
+    /**
+     * This function is used to create a new group instance. Returns the instance object that was created.
+     * ### **[Important]**
+     * - Only for creating group instances.
+     *
+     * @param worldId The ID of the world you want to create an instance in.
+     * @param groupAccessType The type of group instance you are creating. Enum: `GroupAccessType`.
+     * @param ownerId The owner ID of the instance. (Must be the USER ID of the bot account this script is controlling).
+     * @param region The region of the instance. Enum: `InstanceRegionType`.
+     * @param queueEnabled **[Optional]** If the queue is enabled for the instance. Default is `false`.
+     * @param roleIds The role IDs of the group that can join the instance. (You can get the role IDs from the group object).
+     * @param instanceCode **[Optional]** The code of the instance. If not provided, a random code will be generated. (Any 1-5 digit number or characters are valid.)
+     *
+     * @returns {Promise<Inst.Instance>} The instance object that was created.
+     */
+    public generateGroupInstance({
+        worldId,
+        groupAccessType,
+        groupId,
+        region,
+        queueEnabled = false,
+        roleIds,
+        instanceCode,
+    }: Inst.CreateGroupInstanceRequest): Promise<Inst.Instance> {
+        // gnerate a random code that is 1-5 digits long maximum
+        if (!instanceCode) {
+            instanceCode = Math.floor(Math.random() * 99999) + 1;
+        } else {
+            if (instanceCode.toString().length > 5 || instanceCode.toString().length < 1) {
+                throw new Error('The instanceCode must be between 1-5 digits/characters long!');
+            }
+        }
+
+        // making sure all the role IDs are valid and starts with grol_
+        roleIds.forEach((roleId) => {
+            if (!roleId.startsWith('grol_')) {
+                throw new Error('The roleIds are supposed to start with "grol_"! Now cancelling the request.');
+            }
+        });
+
+        const ownerId = groupId;
+
+        const body: Inst.dataKeysCreateGroupInstance = {
+            groupAccessType,
             ownerId,
+            queueEnabled,
             region,
+            roleIds,
+            type: 'group',
+            worldId,
+            instanceCode,
         };
 
         const paramRequest: executeRequestType = {
-            currentRequest: ApiPaths.instances.createInstance,
-            pathFormated: ApiPaths.instances.createInstance.path,
+            currentRequest: ApiPaths.instances.createGroupInstance,
+            pathFormated: ApiPaths.instances.createGroupInstance.path,
             body: body,
         };
 
         return this.executeRequest<Inst.Instance>(paramRequest);
+    }
+
+    /**
+     * This function is used to Generate a new instance ID **ONLY**. It will only return a string you can use to create an instance with. There is no request made to VRChat with this function.
+     * ### **[Important]**
+     * - Only for creating instances that are not group instances!! Group instances HAVE to be created with VRChat API.
+     *
+     * @param worldId The ID of the world you want to create an instance in.
+     * @param region The region of the instance. Enum: `InstanceRegionType`.
+     * @param instanceType The type of instance you are creating. Enum: `InstanceAccessNormalType`.
+     * @param instanceCode **[Optional]** The code of the instance. If not provided, a random code will be generated. (Any 1-5 digit number or characters are valid.)
+     * @param ownerId **[Optional]** The owner ID of the instance. BUT **is Required if the instance isn't public.** (Must be the USER ID of the bot account this script is controlling).
+     *
+     * @returns {Promise<Inst.Instance>} The instance object that was created.
+     */
+    public generateNormalInstanceIdOnly({
+        worldId,
+        region,
+        instanceType,
+        instanceCode,
+        ownerId,
+    }: Inst.CreateRegularInstanceRequest): string {
+        if (instanceType !== Inst.InstanceAccessNormalType.Public) {
+            if (!ownerId) throw new Error('You need to provide the ownerId parameter for a non-public instance!');
+        } else {
+            if (ownerId)
+                console.warn('The ownerId parameter is not required for a public instance! It will be ignored.');
+        }
+
+        // gnerate a random code that is 1-5 digits long maximum
+        if (!instanceCode) {
+            instanceCode = Math.floor(Math.random() * 99999) + 1;
+        } else {
+            if (instanceCode.toString().length > 5 || instanceCode.toString().length < 1) {
+                throw new Error('The instanceCode must be between 1-5 digits/characters long!');
+            }
+        }
+
+        let instanceId = '';
+
+        instanceId = worldId + ':' + instanceCode;
+        const nonce = this.getRandomNonce();
+
+        if (instanceType === Inst.InstanceAccessNormalType.Public) {
+            // Public instance type
+            instanceId += '~region(' + region + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Friends) {
+            // Friends instance type
+            instanceId += '~friends(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Friends_Plus) {
+            // Friends+ instance type
+            instanceId += '~hidden(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else if (instanceType === Inst.InstanceAccessNormalType.Invite) {
+            // Invite instance type
+            instanceId += '~private(' + ownerId + ')~region(' + region + ')~nonce(' + nonce + ')';
+        } else {
+            // Invite+ instance type
+            instanceId += '~private(' + ownerId + ')~canRequestInvite~region(' + region + ')~nonce(' + nonce + ')';
+        }
+
+        return instanceId;
+    }
+
+    /** Return a random UUIDv4 called nonce. Required for creating an instance other then group type instance. */
+    public getRandomNonce() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            const r = (Math.random() * 16) | 0,
+                v = c == 'x' ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        });
     }
 }

--- a/src/requests/InvitesApi.ts
+++ b/src/requests/InvitesApi.ts
@@ -18,11 +18,14 @@ export class InvitesApi extends BaseApi {
 
     /**
      * Sends an invite to a user. Returns the Notification of type `invite` that was sent.
+     * @param userId The user ID to send the invite to. This is the ID of the user you want to invite. It CANNOT be your own user ID. Use `inviteMyselfToInstance` instead.
+     * @param instanceId The instance ID of the instance you want to invite the user to. If you use an Instance Object, you can get the `instance id`` attribute from the object, NOT the ID attribute.
+     * @param messageSlot The slot number of the message. This is a number between 1 and 11. If you don't provide this, it will default to 1.
      */
     public async inviteUser({
         userId,
         instanceId,
-        messageSlot,
+        messageSlot = 1,
     }: Inv.InviteUserRequest): Promise<Notif.SentNotification> {
         const paramRequest: executeRequestType = {
             currentRequest: ApiPaths.invites.inviteUser,

--- a/src/requests/UsersApi.ts
+++ b/src/requests/UsersApi.ts
@@ -150,7 +150,7 @@ export type VRCRankResult = {
  *
  * *Complete rewrite of this part, now way more optimized.*
  */
-export function getVRCRankTags(user: User.User | User.CurrentUser): VRCRankResult {
+export function getVRCRankTags(user: User.User | User.CurrentUser | User.LimitedUser): VRCRankResult {
     // the highest vrcrank we can find in the user's tag is the rank of the user we should return
     // Determine if the user is a troll
     const isTroll = user.tags.includes(User.VRCRanks.Nuisance) || user.tags.includes('system_probable_troll');

--- a/src/types/ApiPaths.ts
+++ b/src/types/ApiPaths.ts
@@ -2,6 +2,7 @@ import { APIPaths } from "./Generics";
 
 export const ApiPaths: APIPaths = {
     apiBasePath: "https://api.vrchat.cloud/api/1",
+    apiBasePath2: "https://vrchat.com/api/1",
     auth: {
         userExist: { path: "/auth/exists", method: "GET", cookiesNeeded: ["none"] },
         getCurrentUserInfo: { path: "/auth/user", method: "GET", cookiesNeeded: ["authCookie", "authorization", "twoFactorAuth"] },
@@ -121,10 +122,11 @@ export const ApiPaths: APIPaths = {
     },
     instances: {
         getInstance: { path: "/instances/{worldId}:{instanceId}", method: "GET", cookiesNeeded: ["authCookie"], requiredQueryParams: ["worldId", "instanceId"] },
-        getInstanceShortName: { path: "/instances/{worldId}:{instanceId}/shortName", method: "GET", cookiesNeeded: ["authCookie"], requiredQueryParams: ["worldId", "instanceId"] },
+        getInstanceShortName: { path: "/instances/{instanceId}/shortName", method: "GET", cookiesNeeded: ["authCookie", "twoFactorAuth"], requiredQueryParams: ["instanceId"], secondPath: true },
         sendSelfInvite: { path: "/instances/{worldId}:{instanceId}/invite", method: "POST", deprecated:true, cookiesNeeded: ["authCookie"], requiredQueryParams: ["worldId", "instanceId"] },
         getInstanceByShortName: { path: "/instances/s/{shortName}", method: "GET", cookiesNeeded: ["authCookie"], requiredQueryParams: ["shortName"] },
-        createInstance: { path: "/instances", method: "POST", cookiesNeeded: ["authCookie"], requiresData:true },
+        createNormalInstance: { path: "/instances/{instanceId}", method: "GET", cookiesNeeded: ["authCookie"], requiredQueryParams: ["instanceId"] },
+        createGroupInstance: { path: "/instances", method: "POST", cookiesNeeded: ["authCookie"], requiresData:true, secondPath: true},
     },
 
     notifications: {

--- a/src/types/Generics.ts
+++ b/src/types/Generics.ts
@@ -26,7 +26,7 @@ import {
     dataKeysUpdateGroupMember,
     dataKeysUpdateGroupRole,
 } from './Groups';
-import { CreateRegularInstanceRequest } from './Instances';
+import { CreateRegularInstanceRequest, dataKeysCreateGroupInstance } from './Instances';
 import {
     dataKeysInviteResponse,
     dataKeysRequestInvite,
@@ -158,6 +158,7 @@ export type subSectionType = {
     deprecated?: boolean;
     requiresData?: boolean;
     notImplemented?: boolean;
+    secondPath?: boolean;
 };
 
 export type subSectionPath = {
@@ -166,6 +167,7 @@ export type subSectionPath = {
 
 export type APIPaths = {
     apiBasePath: string;
+    apiBasePath2: string;
     auth: {
         userExist: subSectionType;
         getCurrentUserInfo: subSectionType;
@@ -288,7 +290,8 @@ export type APIPaths = {
         getInstanceShortName: subSectionType;
         sendSelfInvite: subSectionType;
         getInstanceByShortName: subSectionType;
-        createInstance: subSectionType;
+        createNormalInstance: subSectionType;
+        createGroupInstance: subSectionType;
     };
     notifications: {
         listNotifications: subSectionType;
@@ -382,7 +385,8 @@ export type dataSetKeys =
     | GetOwnTransactionsRequest
     | GetTiliaTOSRequest
     | GetUserBalanceRequest
-    | GetLicenseRequest;
+    | GetLicenseRequest
+    | dataKeysCreateGroupInstance;
 
 export type dataKeys2Fa = {
     code: string;

--- a/src/types/Instances.ts
+++ b/src/types/Instances.ts
@@ -35,9 +35,10 @@ export type Instance = {
      */
     canRequestInvite: boolean;
     permanent: boolean; // todo research more
-    groupAccessType: string; // todo research more
+    groupAccessType?: string; // todo research more
     strict: boolean; // todo research more
-    nonce: string; // todo research more
+    /** Required to generate an instance that isn't public */
+    nonce: string;
     users?: string[]; // todo research more
     hidden?: string; // hidden field is only present if InstanceType is hidden aka "Friends+", and is instance creator. // TODO research more
     friends?: string; //friends field is only present if InstanceType is friends aka "Friends", and is instance creator. // TODO research more
@@ -93,24 +94,54 @@ export enum InstanceRegionType {
 export enum GroupAccessType {
     Group_Public = 'public',
     Group_Plus = 'plus',
-    Group_Members = 'member',
+    Group_Members = 'members',
 }
 
 //! --- Requests --- !//
 
 export type CreateRegularInstanceRequest = {
     worldId: string;
-    ownerId?: string;
     region: InstanceRegionType;
+    instanceCode?: number | string;
+} & (PublicType | Friends_Invite_Type);
+
+export type PublicType = {
+    instanceType: InstanceAccessNormalType.Public;
+    ownerId?: string;
 };
+
+export type Friends_Invite_Type = {
+    instanceType:
+        | InstanceAccessNormalType.Friends
+        | InstanceAccessNormalType.Invite
+        | InstanceAccessNormalType.Invite_Plus
+        | InstanceAccessNormalType.Friends_Plus;
+    /** Only required if the instance isn't of type 'Public' */
+    ownerId: string;
+};
+
+type NonEmptyArray<T> = [T, ...T[]];
 
 export type CreateGroupInstanceRequest = {
     worldId: string;
-    groupAccessType: string;
-    ownerId?: string;
+    groupAccessType: GroupAccessType;
+    /** The GROUP ID of the group you want to create an instance for. */
+    groupId: string;
     region: InstanceRegionType;
+    roleIds: NonEmptyArray<string>;
     queueEnabled?: boolean;
-    roleIds?: string[];
+    instanceCode?: number | string;
+};
+
+export type dataKeysCreateGroupInstance = {
+    groupAccessType: GroupAccessType;
+    ownerId: string;
+    queueEnabled: boolean;
+    region: InstanceRegionType;
+    roleIds: NonEmptyArray<string>;
+    type: 'group';
+    worldId: string;
+    instanceCode: number | string;
 };
 
 /** The Required Parameters to get an instance. */
@@ -121,7 +152,6 @@ export type GetInstanceRequest = {
 
 /** The Required Parameters to get an instance's short name. */
 export type GetInstanceShortNameRequest = {
-    worldId: string;
     instanceId: string;
 };
 
@@ -135,3 +165,11 @@ export type SendSelfInviteRequest = {
 export type GetInstanceByShortName = {
     shortName: string;
 };
+
+export enum InstanceAccessNormalType {
+    Public,
+    Friends_Plus,
+    Friends,
+    Invite,
+    Invite_Plus,
+}

--- a/src/types/Users.ts
+++ b/src/types/Users.ts
@@ -58,6 +58,7 @@ export type CurrentUser = {
     acceptedPrivacyVersion?: number;
     steamId?: string;
     googleId?: string;
+    googleDetails: object; // todo unknown yet, to research more
     steamDetails: object; // todo unknown yet, to research more
     oculusId?: string;
     picoId?: string;
@@ -90,6 +91,7 @@ export type currentUserOrTwoFactorType = twoFactorAuthResponseType | CurrentUser
 export type PastDisplayName = {
     displayName: string;
     updated_at: string;
+    reverted: boolean; // new
 };
 
 /** Typically "Deletion requested" or "Deletion canceled". Other messages like "Deletion completed" may exist, but are these are not possible to see as a regular user.


### PR DESCRIPTION
Instance endpoints were tweaked and refreshed.
- `createInstance` was removed.
- `createNormalInstance` was created to create normal type instances [Public, Friend, Friend+, Invite & Invite+].
- `createGroupInstance` was create to create group instance specifically.
- Current User type was refreshed.
- Some tweak in the Invite system was done.
- More comments and better typing added for instance management.
- Added a function `generateNormalInstanceIdOnly()` to be able to generate the ID for an instance without sending it to VRChat.